### PR TITLE
Don't use namespaced function names

### DIFF
--- a/src/com/palletops/shorthand.clj
+++ b/src/com/palletops/shorthand.clj
@@ -10,7 +10,7 @@
   "Return a function definition form for lazily injecting a var into a
   namespace."
   []
-  `(fn var-fn [ns# sym# v-sym# meta-m#]
+  `(fn ~'var-fn [ns# sym# v-sym# meta-m#]
      (intern
       ns# (with-meta sym# (merge
                            {:arglists '[[& not-yet-loaded]]}


### PR DESCRIPTION
Clojure 1.9 will likely disallow this (alpha11 already does)
