### PR TITLE
Fix invalid fn invocation

### DIFF
--- a/src/com/palletops/shorthand.clj
+++ b/src/com/palletops/shorthand.clj
@@ -10,7 +10,7 @@
   "Return a function definition form for lazily injecting a var into a
   namespace."
   []
-  `(fn var-fn [ns# sym# v-sym# meta-m#]
+  `(fn ~'var-fn [ns# sym# v-sym# meta-m#]
      (intern
       ns# (with-meta sym# (merge
                            {:arglists '[[& not-yet-loaded]]}


### PR DESCRIPTION
Shorthand doesn't work with Clojure 1.9.0 Alpha 12 (and perhaps earlier) because `fn` invocations are checked with a spec that requires fn names to be unqualified symbols. This change just makes var-fn unqualified.
